### PR TITLE
Fix a parsing bug in CelExtraChunk

### DIFF
--- a/aseprite/chunks.py
+++ b/aseprite/chunks.py
@@ -133,7 +133,7 @@ class CelChunk(Chunk):
             self.data['data'] = zlib.decompress(data[start_range:end_range])
 
 class CelExtraChunk(Chunk):
-    celextra_format = '<HLLLL16x'
+    celextra_format = '<LLLLL16x'
     def __init__(self, data, data_offset=0):
         Chunk.__init__(self, data, data_offset)
         cel_struct = Struct(CelExtraChunk.celextra_format)


### PR DESCRIPTION
The flags value in this chunk type is 32 bits, not 16 bits.

(Also, the position/size values are fixed-point, but currently parsed as 32-bit integers. We could divide by 65536.0 to get the correct value as a float, that's probably a separate fix but let me know if you want to roll that in.)